### PR TITLE
fix: 회차 수정 시 기간이 겹치는지 미확인하는 문제 해결

### DIFF
--- a/src/main/java/com/studiop/dormmanagementsystem/service/RoundService.java
+++ b/src/main/java/com/studiop/dormmanagementsystem/service/RoundService.java
@@ -41,9 +41,7 @@ public class RoundService {
 
     @Transactional
     public Round addRound(RoundRequest request) {
-        if (isOverlapping(request.startDate(), request.endDate())) {
-            throw new EntityException(DUPLICATE_ROUND);
-        }
+        isOverlapping(request.startDate(), request.endDate());
         Round round = Round.builder()
                 .name(request.name())
                 .startDate(request.startDate())
@@ -55,9 +53,7 @@ public class RoundService {
 
     @Transactional
     public void updateRound(Long id, RoundRequest request) {
-        if (isOverlapping(request.startDate(), request.endDate())) {
-            throw new EntityException(DUPLICATE_ROUND);
-        }
+        isOverlapping(request.startDate(), request.endDate());
         Round round = getById(id);
         round.updateRound(request.name(), request.startDate(), request.endDate(), request.password());
     }
@@ -93,10 +89,12 @@ public class RoundService {
         return fridgeCountByBuilding;
     }
 
-    private boolean isOverlapping(LocalDate startDate, LocalDate endDate) {
-        return roundRepository.findAll().stream()
+    private void isOverlapping(LocalDate startDate, LocalDate endDate) {
+        if (roundRepository.findAll().stream()
                 .anyMatch(existing ->
                         !(endDate.isBefore(existing.getStartDate()) || startDate.isAfter(existing.getEndDate()))
-                );
+                )) {
+            throw new EntityException(DUPLICATE_ROUND);
+        }
     }
 }


### PR DESCRIPTION
- close #8 

```diff
@Transactional
public Round addRound(RoundRequest request) {
    isOverlapping(request.startDate(), request.endDate());
    Round round = Round.builder()
            .name(request.name())
            .startDate(request.startDate())
            .endDate(request.endDate())
            .password(request.password())
            .build();
    return roundRepository.save(round);
}

@Transactional
public void updateRound(Long id, RoundRequest request) {
+  isOverlapping(request.startDate(), request.endDate());
    Round round = getById(id);
    round.updateRound(request.name(), request.startDate(), request.endDate(), request.password());
}
```

회차 수정 시 기간이 겹치는지 미확인하여 기간이 중복되는 회차가 존재할 수 있는 문제를 해결하였습니다. (b485519)

또한 isOverlapping 함수 내부에서 예외를 던지도록 하여 코드 중복을 제거하였습니다. (e27e282)