### PR TITLE
fix: 이름으로 조회 시 학번 중복 제거 후 반환하도록 수정

### DIFF
--- a/src/main/java/com/studiop/dormmanagementsystem/api/v1/FridgeController.java
+++ b/src/main/java/com/studiop/dormmanagementsystem/api/v1/FridgeController.java
@@ -15,6 +15,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/v1/fridge")
@@ -39,7 +40,11 @@ public class FridgeController {
     @GetMapping("/name/{name}")
     public ResponseEntity<List<String>> getMemberByName(@PathVariable String name) {
         List<Survey> surveysByName = surveyService.getSurveysByName(name);
-        return ResponseEntity.ok(surveysByName.stream().map(Survey::getStudentId).toList());
+
+        List<String> uniqueStudentIds = surveysByName.stream()
+                .map(Survey::getStudentId).distinct().collect(Collectors.toList());
+
+        return ResponseEntity.ok(uniqueStudentIds);
     }
 
     @Operation(summary = "냉장고 신청 목록 전체 조회")


### PR DESCRIPTION
- close #28 

- 냉장고 신청/연장 메뉴에서 이름으로 조회 시 서약서가 N건 제출된 경우 학번을 중복 제거한 후 unique하게 반환하도록 수정하였습니다.

```diff
    public ResponseEntity<List<String>> getMemberByName(@PathVariable String name) {
        List<Survey> surveysByName = surveyService.getSurveysByName(name);
-        return ResponseEntity.ok(surveysByName.stream().map(Survey::getStudentId).toList());
+        List<String> uniqueStudentIds = surveysByName.stream()
+                .map(Survey::getStudentId).distinct().collect(Collectors.toList());

+        return ResponseEntity.ok(uniqueStudentIds);
    }
```